### PR TITLE
refactor: Refactor logging setup to be more readable & expand use cases

### DIFF
--- a/API.md
+++ b/API.md
@@ -34,6 +34,49 @@ new InstanceService(scope: Construct, id: string, props: IInstanceServiceProps)
 
 
 
+### ManagedLoggingPolicy <a name="@renovosolutions/cdk-library-renovo-instance-service.ManagedLoggingPolicy"></a>
+
+#### Initializers <a name="@renovosolutions/cdk-library-renovo-instance-service.ManagedLoggingPolicy.Initializer"></a>
+
+```typescript
+import { ManagedLoggingPolicy } from '@renovosolutions/cdk-library-renovo-instance-service'
+
+new ManagedLoggingPolicy(scope: Construct, id: string, props: IManagedLoggingPolicyProps)
+```
+
+##### `scope`<sup>Required</sup> <a name="@renovosolutions/cdk-library-renovo-instance-service.ManagedLoggingPolicy.parameter.scope"></a>
+
+- *Type:* [`@aws-cdk/core.Construct`](#@aws-cdk/core.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="@renovosolutions/cdk-library-renovo-instance-service.ManagedLoggingPolicy.parameter.id"></a>
+
+- *Type:* `string`
+
+---
+
+##### `props`<sup>Required</sup> <a name="@renovosolutions/cdk-library-renovo-instance-service.ManagedLoggingPolicy.parameter.props"></a>
+
+- *Type:* [`@renovosolutions/cdk-library-renovo-instance-service.IManagedLoggingPolicyProps`](#@renovosolutions/cdk-library-renovo-instance-service.IManagedLoggingPolicyProps)
+
+---
+
+
+
+#### Properties <a name="Properties"></a>
+
+##### `policy`<sup>Required</sup> <a name="@renovosolutions/cdk-library-renovo-instance-service.ManagedLoggingPolicy.property.policy"></a>
+
+```typescript
+public readonly policy: ManagedPolicy;
+```
+
+- *Type:* [`@aws-cdk/aws-iam.ManagedPolicy`](#@aws-cdk/aws-iam.ManagedPolicy)
+
+---
+
+
 
 
 ## Protocols <a name="Protocols"></a>
@@ -67,6 +110,25 @@ public readonly enableCloudwatchLogs: boolean;
 - *Default:* true
 
 Whether or not to enable logging to Cloudwatch Logs.
+
+---
+
+### IManagedLoggingPolicyProps <a name="@renovosolutions/cdk-library-renovo-instance-service.IManagedLoggingPolicyProps"></a>
+
+- *Implemented By:* [`@renovosolutions/cdk-library-renovo-instance-service.IManagedLoggingPolicyProps`](#@renovosolutions/cdk-library-renovo-instance-service.IManagedLoggingPolicyProps)
+
+
+#### Properties <a name="Properties"></a>
+
+##### `os`<sup>Required</sup> <a name="@renovosolutions/cdk-library-renovo-instance-service.IManagedLoggingPolicyProps.property.os"></a>
+
+```typescript
+public readonly os: string;
+```
+
+- *Type:* `string`
+
+The OS of the instance this policy is for.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jest-junit": "^12",
     "jsii": "^1.40.0",
     "jsii-diff": "^1.40.0",
-    "jsii-docgen": "^3.8.0",
+    "jsii-docgen": "^3.8.1",
     "jsii-pacmak": "^1.40.0",
     "json-schema": "^0.3.0",
     "npm-check-updates": "^11",

--- a/test/__snapshots__/instanceservice.test.ts.snap
+++ b/test/__snapshots__/instanceservice.test.ts.snap
@@ -29,7 +29,7 @@ Object {
         },
         "ManagedPolicyArns": Array [
           Object {
-            "Ref": "instanceServiceloggingPolicy5CD2F985",
+            "Ref": "instanceServiceloggingPolicyA64D3A45",
           },
           Object {
             "Fn::Join": Array [
@@ -47,7 +47,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "instanceServiceloggingPolicy5CD2F985": Object {
+    "instanceServiceloggingPolicyA64D3A45": Object {
       "Properties": Object {
         "Description": "Allow instance to log system logs to Cloudwatch",
         "Path": "/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -723,7 +723,7 @@
     chalk "^4.1.2"
     semver "^7.3.5"
 
-"@jsii/spec@^1.39.0", "@jsii/spec@^1.40.0":
+"@jsii/spec@^1.40.0":
   version "1.40.0"
   resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.40.0.tgz#027dd2a9c2c0b49e5974ad6445728dde91569fe3"
   integrity sha512-SJ9Kwz0C53bomYWb5PlESt6v8JmfgqqFjc1annNK+foHxcaUzs3trhKbBXgxhcoApE2pMnUIBj3DG9gLNmKdWw==
@@ -975,9 +975,9 @@
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
 "@types/node@*":
-  version "16.11.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.1.tgz#2e50a649a50fc403433a14f829eface1a3443e97"
-  integrity sha512-PYGcJHL9mwl1Ek3PLiYgyEKtwTMmkMw4vbiyz/ps3pfdRYLVv+SN7qHVAImrjdAXxgluDEw6Ph4lyv+m9UpRmA==
+  version "16.11.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.2.tgz#31c249c136c3f9b35d4b60fb8e50e01a1f0cc9a5"
+  integrity sha512-w34LtBB0OkDTs19FQHXy4Ig/TOXI4zqvXS2Kk1PAsRKZ0I+nik7LlMYxckW0tSNGtvWmzB+mrCTbuEjuB9DVsw==
 
 "@types/node@^10.17.60":
   version "10.17.60"
@@ -2253,9 +2253,9 @@ ecc-jsbn@~0.1.1:
     safer-buffer "^2.1.0"
 
 electron-to-chromium@^1.3.867:
-  version "1.3.874"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.874.tgz#75d68ce2b3a778346916ae1293f80f389ecf439c"
-  integrity sha512-OxEyMXzLi6Y9UMPgyjP6XSuIsgD1xgK2FWnek/toV3G0Zr89bKSuNaX8YRM5hWtSaNEiL/TqubOvwtDTU3pwZA==
+  version "1.3.876"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.876.tgz#fe6f65c9740406f4aa69f10faa8e1d79b81bdf34"
+  integrity sha512-a6LR4738psrubCtGx5HxM/gNlrIsh4eFTNnokgOqvQo81GWd07lLcOjITkAXn2y4lIp18vgS+DGnehj+/oEAxQ==
 
 emittery@^0.8.1:
   version "0.8.1"
@@ -4092,18 +4092,18 @@ jsii-diff@^1.40.0:
     typescript "~3.9.10"
     yargs "^16.2.0"
 
-jsii-docgen@^3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/jsii-docgen/-/jsii-docgen-3.8.0.tgz#cce89df6c92600e4a3402732681cd2f3fcfb2ead"
-  integrity sha512-zRLAm/gyKJbdiV7f4Tp53ftQ4dj2NJwndx5ictQ2ok/XgqCc/l8yy8ac5QF7Dq/imQuv53gmE39Sz/zxelfVsA==
+jsii-docgen@^3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/jsii-docgen/-/jsii-docgen-3.8.1.tgz#71e1bdc3922373a0a9e91a75d3848f83ad644c4a"
+  integrity sha512-UuBEWM60d8bgbKAvCf5RR0oaw/DsmO1PxGkW8j4j3MrkHkbwC5z5beO2xWXbbjmvKjN6WYbrAqGX9AItK4aS4A==
   dependencies:
-    "@jsii/spec" "^1.39.0"
+    "@jsii/spec" "^1.40.0"
     case "^1.6.3"
     fs-extra "^10.0.0"
     glob "^7.2.0"
     glob-promise "^3.4.0"
-    jsii-reflect "^1.39.0"
-    jsii-rosetta "^1.39.0"
+    jsii-reflect "^1.40.0"
+    jsii-rosetta "^1.40.0"
     yargs "^16.2.0"
 
 jsii-pacmak@^1.40.0:
@@ -4125,7 +4125,7 @@ jsii-pacmak@^1.40.0:
     xmlbuilder "^15.1.1"
     yargs "^16.2.0"
 
-jsii-reflect@^1.39.0, jsii-reflect@^1.40.0:
+jsii-reflect@^1.40.0:
   version "1.40.0"
   resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-1.40.0.tgz#f8715f1506059d49294b32fe2c710753dd9545ba"
   integrity sha512-/ccIjkRSfbHCl1MCfwWFaz2RjoAAiNH5teE95Qi11a4gbTu52WcOFIg3Y+8llzHmmLykr9jTDqBtgyzi9WI6dw==
@@ -4137,7 +4137,7 @@ jsii-reflect@^1.39.0, jsii-reflect@^1.40.0:
     oo-ascii-tree "^1.40.0"
     yargs "^16.2.0"
 
-jsii-rosetta@^1.39.0, jsii-rosetta@^1.40.0:
+jsii-rosetta@^1.40.0:
   version "1.40.0"
   resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-1.40.0.tgz#eff34919ed9d4193ddb4a684f6108c82db3feb7c"
   integrity sha512-Gb257CdUbHV8ZRFYflZy7F7alH5X49T+pX2133F7eaoMpRqc0V6jQsphaL4V+S/jK29XOfXtANmq55AvmwsWLQ==
@@ -4710,9 +4710,9 @@ node-modules-regexp@^1.0.0:
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
 node-releases@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.0.tgz#67dc74903100a7deb044037b8a2e5f453bb05400"
-  integrity sha512-aA87l0flFYMzCHpTM3DERFSYxc6lv/BltdbRTOMZuxZ0cwZCD3mejE5n9vLhSJCN++/eOqr77G1IO5uXxlQYWA==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
+  integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
 
 nopt@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
- Moves the logging policy create to a separate construct since the output can be used stand alone.
- Moves the conversion of the ami image to os string to a function.