### PR TITLE
feat: Add CDK aspects to lock down common ports

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -125,7 +125,11 @@
       "type": "runtime"
     },
     {
-      "name": "@renovosolutions/aws-cdk-managed-instance-role",
+      "name": "@renovosolutions/cdk-aspects-library-security-group",
+      "type": "runtime"
+    },
+    {
+      "name": "@renovosolutions/cdk-library-managed-instance-role",
       "type": "runtime"
     }
   ],

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -296,7 +296,7 @@
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @aws-cdk/assert @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import jest jest-junit jsii jsii-diff jsii-docgen jsii-pacmak json-schema npm-check-updates standard-version ts-jest typescript @aws-cdk/aws-ec2 @aws-cdk/aws-iam @aws-cdk/core constructs @aws-cdk/aws-ec2 @aws-cdk/aws-iam @aws-cdk/core @renovosolutions/aws-cdk-managed-instance-role"
+          "exec": "yarn upgrade @aws-cdk/assert @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import jest jest-junit jsii jsii-diff jsii-docgen jsii-pacmak json-schema npm-check-updates standard-version ts-jest typescript @aws-cdk/aws-ec2 @aws-cdk/aws-iam @aws-cdk/core constructs @aws-cdk/aws-ec2 @aws-cdk/aws-iam @aws-cdk/core @renovosolutions/cdk-aspects-library-security-group @renovosolutions/cdk-library-managed-instance-role"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -13,7 +13,8 @@ const project = new AwsCdkConstructLibrary({
     '@aws-cdk/aws-ec2',
   ],
   deps: [
-    '@renovosolutions/aws-cdk-managed-instance-role',
+    '@renovosolutions/cdk-library-managed-instance-role',
+    '@renovosolutions/cdk-aspects-library-security-group',
   ],
   keywords: [
     'cdk',

--- a/API.md
+++ b/API.md
@@ -40,7 +40,7 @@ new InstanceService(scope: Construct, id: string, props: IInstanceServiceProps)
 public readonly instanceProfile: ManagedInstanceRole;
 ```
 
-- *Type:* [`@renovosolutions/aws-cdk-managed-instance-role.ManagedInstanceRole`](#@renovosolutions/aws-cdk-managed-instance-role.ManagedInstanceRole)
+- *Type:* [`@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole`](#@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole)
 
 ---
 
@@ -231,6 +231,50 @@ public readonly enableCloudwatchLogs: boolean;
 - *Default:* true
 
 Whether or not to enable logging to Cloudwatch Logs.
+
+---
+
+##### `enabledNoPublicIngressAspect`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-renovo-instance-service.IInstanceServiceProps.property.enabledNoPublicIngressAspect"></a>
+
+```typescript
+public readonly enabledNoPublicIngressAspect: boolean;
+```
+
+- *Type:* `boolean`
+
+Whether or not to prevent security group from containing rules that allow access from the public internet: Any rule with a source from 0.0.0.0/0 or ::/0.
+
+If these sources are used when this is enabled and error will be added to CDK metadata and deployment and synth will fail.
+
+---
+
+##### `enableNoDBPortsAspect`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-renovo-instance-service.IInstanceServiceProps.property.enableNoDBPortsAspect"></a>
+
+```typescript
+public readonly enableNoDBPortsAspect: boolean;
+```
+
+- *Type:* `boolean`
+- *Default:* true
+
+Whether or not to prevent security group from containing rules that allow access to relational DB ports: MySQL, PostgreSQL, MariaDB, Oracle, SQL Server.
+
+If these ports are opened when this is enabled an error will be added to CDK metadata and deployment and synth will fail.
+
+---
+
+##### `enableNoRemoteManagementPortsAspect`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-renovo-instance-service.IInstanceServiceProps.property.enableNoRemoteManagementPortsAspect"></a>
+
+```typescript
+public readonly enableNoRemoteManagementPortsAspect: boolean;
+```
+
+- *Type:* `boolean`
+- *Default:* true
+
+Whether or not to prevent security group from containing rules that allow access to remote management ports: SSH, RDP, WinRM, WinRM over HTTPs.
+
+If these ports are opened when this is enabled an error will be added to CDK metadata and deployment and synth will fail.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jest-junit": "^12",
     "jsii": "^1.41.0",
     "jsii-diff": "^1.41.0",
-    "jsii-docgen": "^3.8.10",
+    "jsii-docgen": "^3.8.12",
     "jsii-pacmak": "^1.41.0",
     "json-schema": "^0.3.0",
     "npm-check-updates": "^11",
@@ -68,7 +68,8 @@
     "@aws-cdk/aws-ec2": "^1.129.0",
     "@aws-cdk/aws-iam": "^1.129.0",
     "@aws-cdk/core": "^1.129.0",
-    "@renovosolutions/aws-cdk-managed-instance-role": "^0.0.14"
+    "@renovosolutions/cdk-aspects-library-security-group": "^0.1.0",
+    "@renovosolutions/cdk-library-managed-instance-role": "^0.0.16"
   },
   "bundledDependencies": [],
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -723,7 +723,7 @@
     chalk "^4.1.2"
     semver "^7.3.5"
 
-"@jsii/spec@^1.40.0", "@jsii/spec@^1.41.0":
+"@jsii/spec@^1.41.0":
   version "1.41.0"
   resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.41.0.tgz#d504c8536139a97986b1ec63201d3575972e1e9c"
   integrity sha512-sN7x6C0DGLngiO6SkrM/7gVaHyeja59bDZODZtBXIq8kBIC+GgAFS8P0s1e5FpU9mHHvvHq4rvzvcIbxw0nkXw==
@@ -840,10 +840,18 @@
   resolved "https://registry.yarnpkg.com/@oozcitak/util/-/util-8.3.8.tgz#10f65fe1891fd8cde4957360835e78fd1936bfdd"
   integrity sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==
 
-"@renovosolutions/aws-cdk-managed-instance-role@^0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@renovosolutions/aws-cdk-managed-instance-role/-/aws-cdk-managed-instance-role-0.0.14.tgz#f9ed0e4cc0d093401da57ea01366915acae23eeb"
-  integrity sha512-OXwvSGpSZKYFNOrSuzR5ximhG7JMFR3A2u0d6z7PADJoUSq1XDm9aY9iSZ2H0buBkPBHqICo9sYaU8L4K3z6aQ==
+"@renovosolutions/cdk-aspects-library-security-group@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@renovosolutions/cdk-aspects-library-security-group/-/cdk-aspects-library-security-group-0.1.0.tgz#20632644265d5336782c1032de6d5d1b3127b5d7"
+  integrity sha512-61ILIpHmaipX/oLyi+SQfQpEs++IhZeFuSFIlGEFHb+uHWtK4ga9NAHgGJMtAF0iEnmAb6dSu/ENuxQ8TDj1YA==
+  dependencies:
+    "@aws-cdk/aws-ec2" "^1.129.0"
+    "@aws-cdk/core" "^1.129.0"
+
+"@renovosolutions/cdk-library-managed-instance-role@^0.0.16":
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/@renovosolutions/cdk-library-managed-instance-role/-/cdk-library-managed-instance-role-0.0.16.tgz#7be9dcec04b17520d88435c5fbac486332bb166c"
+  integrity sha512-L0eSBZTpRWdoqMByHhrbmcyOfhwf1XakascIPIWcxoM8EQUYygZCVqErYjzi2aeEUZAEX1mvivSQZWwLQhf8JA==
   dependencies:
     "@aws-cdk/aws-iam" "^1.129.0"
     "@aws-cdk/core" "^1.129.0"
@@ -1561,9 +1569,9 @@ camelcase@^6.2.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001271:
-  version "1.0.30001271"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz#0dda0c9bcae2cf5407cd34cac304186616cc83e8"
-  integrity sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==
+  version "1.0.30001272"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001272.tgz#8e9790ff995e9eb6e1f4c45cd07ddaa87cddbb14"
+  integrity sha512-DV1j9Oot5dydyH1v28g25KoVm7l8MTxazwuiH3utWiAS6iL/9Nh//TGwqFEeqqN8nnWYQ8HHhUq+o4QPt9kvYw==
 
 case@^1.6.3:
   version "1.6.3"
@@ -2253,9 +2261,9 @@ ecc-jsbn@~0.1.1:
     safer-buffer "^2.1.0"
 
 electron-to-chromium@^1.3.878:
-  version "1.3.881"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.881.tgz#1282881dffa57b6111fb94cb196e558be249fbfb"
-  integrity sha512-XoAaO4CXk7FXtF2JH0PJ7KgHL1PyZ76G+NhuL337pMiOGlEWwTTSzMQyYZvxN97d9KhdLMOW8XVVk/6sN2Xflw==
+  version "1.3.883"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.883.tgz#cc409921469b3aa6ab6efd65cc2a4375128bb703"
+  integrity sha512-goyjNx4wB9j911PBteb+AXNbErug7rJVkmDXWdw5SCVn2JlARBwsqucPkvp1h5mXWxHUbBRK3bwXTrqSxSiAIQ==
 
 emittery@^0.8.1:
   version "0.8.1"
@@ -4092,18 +4100,19 @@ jsii-diff@^1.41.0:
     typescript "~3.9.10"
     yargs "^16.2.0"
 
-jsii-docgen@^3.8.10:
-  version "3.8.10"
-  resolved "https://registry.yarnpkg.com/jsii-docgen/-/jsii-docgen-3.8.10.tgz#e49c35bb5a49ed186b5e1bb8350ad46dcf15d360"
-  integrity sha512-EHDATsDLgTflke5vVz7qvIfIU7vF/wuv5wE3kw9ZOq0WkKF79G1c1aT0gN7ltMdwNRgNT9noTk55qvDdBNFPdw==
+jsii-docgen@^3.8.12:
+  version "3.8.12"
+  resolved "https://registry.yarnpkg.com/jsii-docgen/-/jsii-docgen-3.8.12.tgz#32dfaa44ab21385a125257b0e9db13cce82fdd32"
+  integrity sha512-uISdMEu4vIZ4rzCH3Bak6zH4+lgtLHgxheIDRNGI6mBjj0UfgbiQSIcMKnrrNOXh+eb5O+rA+bSzopBSfJ9F0A==
   dependencies:
-    "@jsii/spec" "^1.40.0"
+    "@jsii/spec" "^1.41.0"
     case "^1.6.3"
     fs-extra "^10.0.0"
     glob "^7.2.0"
     glob-promise "^3.4.0"
-    jsii-reflect "^1.40.0"
-    jsii-rosetta "^1.40.0"
+    jsii-reflect "^1.41.0"
+    jsii-rosetta "^1.41.0"
+    semver "^7.3.5"
     yargs "^16.2.0"
 
 jsii-pacmak@^1.41.0:
@@ -4125,7 +4134,7 @@ jsii-pacmak@^1.41.0:
     xmlbuilder "^15.1.1"
     yargs "^16.2.0"
 
-jsii-reflect@^1.40.0, jsii-reflect@^1.41.0:
+jsii-reflect@^1.41.0:
   version "1.41.0"
   resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-1.41.0.tgz#3c8fbcbbb7e2853b7c2a59384524ccbd2d9d832c"
   integrity sha512-KQaAXQ38hyREs7IuBChZldSyvW1gezHRezGKGc6BZILwlIX330F3GIauJ2rJKJinh/Lo/DlMfd0k1mxdBz/W9A==
@@ -4137,7 +4146,7 @@ jsii-reflect@^1.40.0, jsii-reflect@^1.41.0:
     oo-ascii-tree "^1.41.0"
     yargs "^16.2.0"
 
-jsii-rosetta@^1.40.0, jsii-rosetta@^1.41.0:
+jsii-rosetta@^1.41.0:
   version "1.41.0"
   resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-1.41.0.tgz#ddf3f49738489d8330aa4eff96f0a9c8c811792d"
   integrity sha512-wSjMqRBhjBKB8kx+gIXE7YXoiOlTFH/ugksHz2K4UwqriPmEHue8b7LkV3d/mD8xuhXWS6ekGAz67Gd1RSB7Sg==


### PR DESCRIPTION
BREAKING CHANGE: Prevents usage of WinRM, WinRM over HTTPS, SSH, RDP, MySQL, MariaDB, PostgreSQL, MS SQL, Oracle ports in security group rules. Also locks down and prevents any rule from `0.0.0.0/0` or `::/0`. These can be overridden but generally shouldn't be without specific use cases. Management should be done with AWS SSM or other tools, DB ports typically shouldn't be used unless this is a DB instance, and no instance should be directly available on the web without a load balancer or other proxy.

Closes #5 