### PR TITLE
refactor: Replace IAM Instance profile override with normal role setup

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -110,7 +110,7 @@
     },
     {
       "name": "@renovosolutions/cdk-library-managed-instance-role",
-      "version": "^2.1.42",
+      "version": "^2.2.0",
       "type": "runtime"
     }
   ],

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -20,7 +20,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     'projen',
   ],
   deps: [
-    '@renovosolutions/cdk-library-managed-instance-role@^2.1.42',
+    '@renovosolutions/cdk-library-managed-instance-role@^2.2.0',
     '@renovosolutions/cdk-aspects-library-security-group@^2.0.43',
   ],
   depsUpgrade: true,

--- a/API.md
+++ b/API.md
@@ -52,7 +52,8 @@ new InstanceService(scope: Construct, id: string, props: InstanceServiceProps)
 | [`instanceEc2PublicDnsName`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertyinstanceec2publicdnsname)<span title="Required">*</span> | `string` | Public DNS name for this instance assigned by EC2. |
 | [`instanceId`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertyinstanceid)<span title="Required">*</span> | `string` | The instance's ID. |
 | [`instancePrivateIp`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertyinstanceprivateip)<span title="Required">*</span> | `string` | Private IP for this instance. |
-| [`instanceProfile`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertyinstanceprofile)<span title="Required">*</span> | [`@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole`](#@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole) | The instance profile associated with this instance. |
+| [`instanceProfile`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertyinstanceprofile)<span title="Required">*</span> | [`aws-cdk-lib.aws_iam.CfnInstanceProfile`](#aws-cdk-lib.aws_iam.CfnInstanceProfile) | The instance profile associated with this instance. |
+| [`instanceRole`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertyinstancerole)<span title="Required">*</span> | [`@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole`](#@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole) | The instance role associated with this instance. |
 | [`osType`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertyostype)<span title="Required">*</span> | [`aws-cdk-lib.aws_ec2.OperatingSystemType`](#aws-cdk-lib.aws_ec2.OperatingSystemType) | The type of OS the instance is running. |
 | [`securityGroup`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertysecuritygroup)<span title="Required">*</span> | [`aws-cdk-lib.aws_ec2.SecurityGroup`](#aws-cdk-lib.aws_ec2.SecurityGroup) | The security group associated with this instance. |
 
@@ -157,12 +158,24 @@ Private IP for this instance.
 ##### `instanceProfile`<sup>Required</sup> <a name="@renovosolutions/cdk-library-renovo-instance-service.InstanceService.property.instanceProfile" id="renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertyinstanceprofile"></a>
 
 ```typescript
-public readonly instanceProfile: ManagedInstanceRole;
+public readonly instanceProfile: CfnInstanceProfile;
+```
+
+- *Type:* [`aws-cdk-lib.aws_iam.CfnInstanceProfile`](#aws-cdk-lib.aws_iam.CfnInstanceProfile)
+
+The instance profile associated with this instance.
+
+---
+
+##### `instanceRole`<sup>Required</sup> <a name="@renovosolutions/cdk-library-renovo-instance-service.InstanceService.property.instanceRole" id="renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertyinstancerole"></a>
+
+```typescript
+public readonly instanceRole: ManagedInstanceRole;
 ```
 
 - *Type:* [`@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole`](#@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole)
 
-The instance profile associated with this instance.
+The instance role associated with this instance.
 
 ---
 
@@ -333,6 +346,7 @@ const instanceServiceProps: InstanceServiceProps = { ... }
 | [`enabledNoPublicIngressAspect`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertyenablednopublicingressaspect) | `boolean` | Whether or not to prevent security group from containing rules that allow access from the public internet: Any rule with a source from 0.0.0.0/0 or ::/0. |
 | [`enableNoDBPortsAspect`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertyenablenodbportsaspect) | `boolean` | Whether or not to prevent security group from containing rules that allow access to relational DB ports: MySQL, PostgreSQL, MariaDB, Oracle, SQL Server. |
 | [`enableNoRemoteManagementPortsAspect`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertyenablenoremotemanagementportsaspect) | `boolean` | Whether or not to prevent security group from containing rules that allow access to remote management ports: SSH, RDP, WinRM, WinRM over HTTPs. |
+| [`instanceRole`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertyinstancerole) | [`aws-cdk-lib.aws_iam.Role`](#aws-cdk-lib.aws_iam.Role) | The role to use for this instance. |
 | [`keyName`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertykeyname) | `string` | Name of the SSH keypair to grant access to the instance. |
 | [`privateIpAddress`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertyprivateipaddress) | `string` | Defines a private IP address to associate with the instance. |
 | [`subnetType`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertysubnettype) | [`aws-cdk-lib.aws_ec2.SubnetType`](#aws-cdk-lib.aws_ec2.SubnetType) | The subnet type to launch this service in. |
@@ -507,6 +521,19 @@ public readonly enableNoRemoteManagementPortsAspect: boolean;
 Whether or not to prevent security group from containing rules that allow access to remote management ports: SSH, RDP, WinRM, WinRM over HTTPs.
 
 If these ports are opened when this is enabled an error will be added to CDK metadata and deployment and synth will fail.
+
+---
+
+##### `instanceRole`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-renovo-instance-service.InstanceServiceProps.property.instanceRole" id="renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertyinstancerole"></a>
+
+```typescript
+public readonly instanceRole: Role;
+```
+
+- *Type:* [`aws-cdk-lib.aws_iam.Role`](#aws-cdk-lib.aws_iam.Role)
+- *Default:* ManagedInstanceRole
+
+The role to use for this instance.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@renovosolutions/cdk-aspects-library-security-group": "^2.0.43",
-    "@renovosolutions/cdk-library-managed-instance-role": "^2.1.42"
+    "@renovosolutions/cdk-library-managed-instance-role": "^2.2.0"
   },
   "keywords": [
     "aws-cdk",

--- a/test/__snapshots__/instanceservice.test.ts.snap
+++ b/test/__snapshots__/instanceservice.test.ts.snap
@@ -29,12 +29,12 @@ Object {
     },
     "instanceServiceinstanceBB291B7B": Object {
       "DependsOn": Array [
-        "instanceServiceinstanceInstanceRole1F4C1765",
+        "instanceServiceinstanceRoleroleC95CA18D",
       ],
       "Properties": Object {
         "AvailabilityZone": "dummy1a",
         "IamInstanceProfile": Object {
-          "Ref": "instanceServiceinstanceRoleinstanceProfile95F55675",
+          "Ref": "instanceServiceinstanceInstanceProfile1C790C5B",
         },
         "ImageId": "ami-1234",
         "InstanceType": "t3.micro",
@@ -75,34 +75,11 @@ Object {
       "Properties": Object {
         "Roles": Array [
           Object {
-            "Ref": "instanceServiceinstanceInstanceRole1F4C1765",
+            "Ref": "instanceServiceinstanceRoleroleC95CA18D",
           },
         ],
       },
       "Type": "AWS::IAM::InstanceProfile",
-    },
-    "instanceServiceinstanceInstanceRole1F4C1765": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "ec2.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Tags": Array [
-          Object {
-            "Key": "Name",
-            "Value": "TestStack/instanceService/instance",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
     },
     "instanceServiceinstanceLaunchTemplate1A9ECACA": Object {
       "Properties": Object {
@@ -114,16 +91,6 @@ Object {
         "LaunchTemplateName": "instanceLaunchTemplate",
       },
       "Type": "AWS::EC2::LaunchTemplate",
-    },
-    "instanceServiceinstanceRoleinstanceProfile95F55675": Object {
-      "Properties": Object {
-        "Roles": Array [
-          Object {
-            "Ref": "instanceServiceinstanceRoleroleC95CA18D",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::InstanceProfile",
     },
     "instanceServiceinstanceRoleroleC95CA18D": Object {
       "Properties": Object {

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,10 +676,10 @@
   resolved "https://registry.yarnpkg.com/@renovosolutions/cdk-aspects-library-security-group/-/cdk-aspects-library-security-group-2.0.67.tgz#8aefe8c0521e014a2a95b15a2b9a47aee25afb07"
   integrity sha512-GBCSYT0hayzZdTbBJzJSzy9OnfEz12rXtbu+pU26WzdtKr8g5BTjlK7aetAXlGbHf+JUPt4ln003rFdh1NMgiw==
 
-"@renovosolutions/cdk-library-managed-instance-role@^2.1.42":
-  version "2.1.66"
-  resolved "https://registry.yarnpkg.com/@renovosolutions/cdk-library-managed-instance-role/-/cdk-library-managed-instance-role-2.1.66.tgz#dfdd6164191719c14bd1fe598205bb080f3d2b1c"
-  integrity sha512-TY58rILhnX1NTjGanVVnx4kzEW84jioniyB6FqLkGtoiTbw8WwSYhH8L3YnEWrpK9buODIKE2eebTY/F0uWCmg==
+"@renovosolutions/cdk-library-managed-instance-role@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@renovosolutions/cdk-library-managed-instance-role/-/cdk-library-managed-instance-role-2.2.0.tgz#784795f29ed169633382012d6b29d87f7b79b6bf"
+  integrity sha512-N4ihJ79uj55EYcNQM+VVniCfbspKxxdfZ4WdFenA9pv/9kbKuEt780cDwUxxlwO8tK0zYh6od7t0y+EkEWN3Qg==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"


### PR DESCRIPTION
With changes to `ManagedInstanceRole` we no longer need a somewhat hacky override on the instance role setup.