### PR TITLE
feat: Custom instance role should always be a `ManagedInstanceRole`

### DIFF
--- a/API.md
+++ b/API.md
@@ -53,7 +53,7 @@ new InstanceService(scope: Construct, id: string, props: InstanceServiceProps)
 | [`instanceId`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertyinstanceid)<span title="Required">*</span> | `string` | The instance's ID. |
 | [`instancePrivateIp`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertyinstanceprivateip)<span title="Required">*</span> | `string` | Private IP for this instance. |
 | [`instanceProfile`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertyinstanceprofile)<span title="Required">*</span> | [`aws-cdk-lib.aws_iam.CfnInstanceProfile`](#aws-cdk-lib.aws_iam.CfnInstanceProfile) | The instance profile associated with this instance. |
-| [`instanceRole`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertyinstancerole)<span title="Required">*</span> | [`aws-cdk-lib.aws_iam.Role`](#aws-cdk-lib.aws_iam.Role) | The instance role associated with this instance. |
+| [`instanceRole`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertyinstancerole)<span title="Required">*</span> | [`@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole`](#@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole) | The instance role associated with this instance. |
 | [`osType`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertyostype)<span title="Required">*</span> | [`aws-cdk-lib.aws_ec2.OperatingSystemType`](#aws-cdk-lib.aws_ec2.OperatingSystemType) | The type of OS the instance is running. |
 | [`securityGroup`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertysecuritygroup)<span title="Required">*</span> | [`aws-cdk-lib.aws_ec2.SecurityGroup`](#aws-cdk-lib.aws_ec2.SecurityGroup) | The security group associated with this instance. |
 
@@ -170,10 +170,10 @@ The instance profile associated with this instance.
 ##### `instanceRole`<sup>Required</sup> <a name="@renovosolutions/cdk-library-renovo-instance-service.InstanceService.property.instanceRole" id="renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropertyinstancerole"></a>
 
 ```typescript
-public readonly instanceRole: Role;
+public readonly instanceRole: ManagedInstanceRole;
 ```
 
-- *Type:* [`aws-cdk-lib.aws_iam.Role`](#aws-cdk-lib.aws_iam.Role)
+- *Type:* [`@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole`](#@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole)
 
 The instance role associated with this instance.
 
@@ -346,7 +346,7 @@ const instanceServiceProps: InstanceServiceProps = { ... }
 | [`enabledNoPublicIngressAspect`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertyenablednopublicingressaspect) | `boolean` | Whether or not to prevent security group from containing rules that allow access from the public internet: Any rule with a source from 0.0.0.0/0 or ::/0. |
 | [`enableNoDBPortsAspect`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertyenablenodbportsaspect) | `boolean` | Whether or not to prevent security group from containing rules that allow access to relational DB ports: MySQL, PostgreSQL, MariaDB, Oracle, SQL Server. |
 | [`enableNoRemoteManagementPortsAspect`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertyenablenoremotemanagementportsaspect) | `boolean` | Whether or not to prevent security group from containing rules that allow access to remote management ports: SSH, RDP, WinRM, WinRM over HTTPs. |
-| [`instanceRole`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertyinstancerole) | [`aws-cdk-lib.aws_iam.Role`](#aws-cdk-lib.aws_iam.Role) | The role to use for this instance. |
+| [`instanceRole`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertyinstancerole) | [`@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole`](#@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole) | The role to use for this instance. |
 | [`keyName`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertykeyname) | `string` | Name of the SSH keypair to grant access to the instance. |
 | [`privateIpAddress`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertyprivateipaddress) | `string` | Defines a private IP address to associate with the instance. |
 | [`subnetType`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertysubnettype) | [`aws-cdk-lib.aws_ec2.SubnetType`](#aws-cdk-lib.aws_ec2.SubnetType) | The subnet type to launch this service in. |
@@ -527,11 +527,11 @@ If these ports are opened when this is enabled an error will be added to CDK met
 ##### `instanceRole`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-renovo-instance-service.InstanceServiceProps.property.instanceRole" id="renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertyinstancerole"></a>
 
 ```typescript
-public readonly instanceRole: Role;
+public readonly instanceRole: ManagedInstanceRole;
 ```
 
-- *Type:* [`aws-cdk-lib.aws_iam.Role`](#aws-cdk-lib.aws_iam.Role)
-- *Default:* ManagedInstanceRole
+- *Type:* [`@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole`](#@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole)
+- *Default:* A new ManagedInstanceRole will be created for this instance
 
 The role to use for this instance.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,9 +115,9 @@ export interface InstanceServiceProps {
   /**
    * The role to use for this instance
    *
-   * @default ManagedInstanceRole
+   * @default - A new ManagedInstanceRole will be created for this instance
    */
-  readonly instanceRole?: iam.Role;
+  readonly instanceRole?: ManagedInstanceRole;
 }
 
 export interface ManagedLoggingPolicyProps {
@@ -193,7 +193,7 @@ export class InstanceService extends Construct {
   /**
    * The instance role associated with this instance.
    */
-  public readonly instanceRole: iam.Role;
+  public readonly instanceRole: ManagedInstanceRole;
   /**
    * The security group associated with this instance.
    */
@@ -265,7 +265,7 @@ export class InstanceService extends Construct {
         ssmManagementEnabled: true,
         managedPolicies,
         createInstanceProfile: false,
-      }).role;
+      });
     }
 
     let allowAllOutbound: boolean = (props.allowAllOutbound === undefined) ? true : props.allowAllOutbound;
@@ -296,7 +296,7 @@ export class InstanceService extends Construct {
         onePerAz: true,
         availabilityZones: props.availabilityZones,
       },
-      role: this.instanceRole,
+      role: this.instanceRole.role,
     });
 
     this.instanceProfile = this.instance.node.tryFindChild('InstanceProfile') as iam.CfnInstanceProfile;

--- a/test/__snapshots__/customrole.test.ts.snap
+++ b/test/__snapshots__/customrole.test.ts.snap
@@ -29,7 +29,7 @@ Object {
     },
     "instanceServiceinstanceBB291B7B": Object {
       "DependsOn": Array [
-        "roleC7B7E775",
+        "role08402BCB",
       ],
       "Properties": Object {
         "AvailabilityZone": "dummy1a",
@@ -75,7 +75,7 @@ Object {
       "Properties": Object {
         "Roles": Array [
           Object {
-            "Ref": "roleC7B7E775",
+            "Ref": "role08402BCB",
           },
         ],
       },
@@ -132,7 +132,7 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "roleC7B7E775": Object {
+    "role08402BCB": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -146,8 +146,44 @@ Object {
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
+              ],
+            ],
+          },
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AmazonSSMDirectoryServiceAccess",
+              ],
+            ],
+          },
+        ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "roleinstanceProfileFF411810": Object {
+      "Properties": Object {
+        "Roles": Array [
+          Object {
+            "Ref": "role08402BCB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
     },
     "vpcA2121C38": Object {
       "Properties": Object {

--- a/test/customrole.test.ts
+++ b/test/customrole.test.ts
@@ -1,4 +1,5 @@
-import { App, Stack, aws_ec2 as ec2, aws_iam as iam } from 'aws-cdk-lib';
+import { ManagedInstanceRole } from '@renovosolutions/cdk-library-managed-instance-role';
+import { App, Stack, aws_ec2 as ec2 } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { InstanceService } from '../src/index';
 
@@ -30,9 +31,7 @@ test('Snapshot', () => {
     windows: true,
   });
 
-  const role = new iam.Role(stack, 'role', {
-    assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
-  });
+  const role = new ManagedInstanceRole(stack, 'role', {});
 
   new InstanceService(stack, 'instanceService', {
     name: 'snapshot',


### PR DESCRIPTION
While sometimes creating a role independently of the instance is required that role should always be a `ManagedInstanceRole`. We want to enforce the policies that includes by default.