### PR TITLE
feat: Allow optionally providing a security group

### DIFF
--- a/API.md
+++ b/API.md
@@ -349,6 +349,7 @@ const instanceServiceProps: InstanceServiceProps = { ... }
 | [`instanceRole`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertyinstancerole) | [`@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole`](#@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole) | The role to use for this instance. |
 | [`keyName`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertykeyname) | `string` | Name of the SSH keypair to grant access to the instance. |
 | [`privateIpAddress`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertyprivateipaddress) | `string` | Defines a private IP address to associate with the instance. |
+| [`securityGroup`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertysecuritygroup) | [`aws-cdk-lib.aws_ec2.SecurityGroup`](#aws-cdk-lib.aws_ec2.SecurityGroup) | The security group to use for this instance. |
 | [`subnetType`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertysubnettype) | [`aws-cdk-lib.aws_ec2.SubnetType`](#aws-cdk-lib.aws_ec2.SubnetType) | The subnet type to launch this service in. |
 | [`userData`](#renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertyuserdata) | [`aws-cdk-lib.aws_ec2.UserData`](#aws-cdk-lib.aws_ec2.UserData) | The user data to apply to the instance. |
 
@@ -558,6 +559,19 @@ public readonly privateIpAddress: string;
 - *Type:* `string`
 
 Defines a private IP address to associate with the instance.
+
+---
+
+##### `securityGroup`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-renovo-instance-service.InstanceServiceProps.property.securityGroup" id="renovosolutionscdklibraryrenovoinstanceserviceinstanceservicepropspropertysecuritygroup"></a>
+
+```typescript
+public readonly securityGroup: SecurityGroup;
+```
+
+- *Type:* [`aws-cdk-lib.aws_ec2.SecurityGroup`](#aws-cdk-lib.aws_ec2.SecurityGroup)
+- *Default:* A new SecurityGroup will be created for this instance
+
+The security group to use for this instance.
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,12 @@ export interface InstanceServiceProps {
    * @default - A new ManagedInstanceRole will be created for this instance
    */
   readonly instanceRole?: ManagedInstanceRole;
+  /**
+   * The security group to use for this instance
+   *
+   * @default - A new SecurityGroup will be created for this instance
+   */
+  readonly securityGroup?: ec2.SecurityGroup;
 }
 
 export interface ManagedLoggingPolicyProps {
@@ -271,12 +277,16 @@ export class InstanceService extends Construct {
     let allowAllOutbound: boolean = (props.allowAllOutbound === undefined) ? true : props.allowAllOutbound;
     let disableInlineRules: boolean = (props.disableInlineRules === undefined) ? false : props.disableInlineRules;
 
-    this.securityGroup = new ec2.SecurityGroup(this, 'securityGroup', {
-      allowAllOutbound: allowAllOutbound,
-      vpc: props.vpc,
-      description: `The security group applied to the instance service for ${ props.name }`,
-      disableInlineRules: disableInlineRules,
-    });
+    if (props.securityGroup) {
+      this.securityGroup = props.securityGroup;
+    } else {
+      this.securityGroup = new ec2.SecurityGroup(this, 'securityGroup', {
+        allowAllOutbound: allowAllOutbound,
+        vpc: props.vpc,
+        description: `The security group applied to the instance service for ${ props.name }`,
+        disableInlineRules: disableInlineRules,
+      });
+    }
 
     this.instance = new ec2.Instance(this, 'instance', {
       instanceType: props.instanceType,

--- a/test/__snapshots__/customsg.test.ts.snap
+++ b/test/__snapshots__/customsg.test.ts.snap
@@ -1,0 +1,712 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Snapshot 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "instanceServiceACD550C60": Object {
+      "Properties": Object {
+        "HostedZoneId": "DUMMY",
+        "Name": "snapshot.example.com.",
+        "ResourceRecords": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "instanceServiceinstanceBB291B7B",
+              "PrivateIp",
+            ],
+          },
+        ],
+        "TTL": "1800",
+        "Type": "A",
+      },
+      "Type": "AWS::Route53::RecordSet",
+    },
+    "instanceServiceinstanceBB291B7B": Object {
+      "DependsOn": Array [
+        "instanceServiceinstanceRoleroleC95CA18D",
+      ],
+      "Properties": Object {
+        "AvailabilityZone": "dummy1a",
+        "IamInstanceProfile": Object {
+          "Ref": "instanceServiceinstanceInstanceProfile1C790C5B",
+        },
+        "ImageId": "ami-1234",
+        "InstanceType": "t3.micro",
+        "LaunchTemplate": Object {
+          "LaunchTemplateName": "instanceLaunchTemplate",
+          "Version": Object {
+            "Fn::GetAtt": Array [
+              "instanceServiceinstanceLaunchTemplate1A9ECACA",
+              "LatestVersionNumber",
+            ],
+          },
+        },
+        "PropagateTagsToVolumeOnCreation": true,
+        "SecurityGroupIds": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "sg29196201",
+              "GroupId",
+            ],
+          },
+        ],
+        "SubnetId": Object {
+          "Ref": "vpcPrivateSubnet1Subnet934893E8",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "snapshot.example.com",
+          },
+        ],
+        "UserData": Object {
+          "Fn::Base64": "<powershell></powershell>",
+        },
+      },
+      "Type": "AWS::EC2::Instance",
+    },
+    "instanceServiceinstanceInstanceProfile1C790C5B": Object {
+      "Properties": Object {
+        "Roles": Array [
+          Object {
+            "Ref": "instanceServiceinstanceRoleroleC95CA18D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+    "instanceServiceinstanceLaunchTemplate1A9ECACA": Object {
+      "Properties": Object {
+        "LaunchTemplateData": Object {
+          "MetadataOptions": Object {
+            "HttpTokens": "required",
+          },
+        },
+        "LaunchTemplateName": "instanceLaunchTemplate",
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "instanceServiceinstanceRoleroleC95CA18D": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ec2.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Ref": "instanceServiceloggingPolicyA64D3A45",
+          },
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "instanceServiceloggingPolicyA64D3A45": Object {
+      "Properties": Object {
+        "Description": "Allow instance to log system logs to Cloudwatch",
+        "Path": "/",
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:PutLogEvents",
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                "arn:aws:logs:us-east-1:123456789012:log-group:/windows/logs",
+                "arn:aws:logs:us-east-1:123456789012:log-group:/windows/logs/*",
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::ManagedPolicy",
+    },
+    "sg29196201": Object {
+      "Properties": Object {
+        "GroupDescription": "TestStack/sg",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "vpcA2121C38",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "vpcA2121C38": Object {
+      "Properties": Object {
+        "CidrBlock": "10.0.0.0/16",
+        "EnableDnsHostnames": true,
+        "EnableDnsSupport": true,
+        "InstanceTenancy": "default",
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::VPC",
+    },
+    "vpcIGWE57CBDCA": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::InternetGateway",
+    },
+    "vpcPrivateSubnet1DefaultRoute1AA8E2E5": Object {
+      "Properties": Object {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId": Object {
+          "Ref": "vpcPublicSubnet1NATGateway9C16659E",
+        },
+        "RouteTableId": Object {
+          "Ref": "vpcPrivateSubnet1RouteTableB41A48CC",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "vpcPrivateSubnet1RouteTableAssociation67945127": Object {
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "vpcPrivateSubnet1RouteTableB41A48CC",
+        },
+        "SubnetId": Object {
+          "Ref": "vpcPrivateSubnet1Subnet934893E8",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "vpcPrivateSubnet1RouteTableB41A48CC": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PrivateSubnet1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "vpcA2121C38",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "vpcPrivateSubnet1Subnet934893E8": Object {
+      "Properties": Object {
+        "AvailabilityZone": "dummy1a",
+        "CidrBlock": "10.0.96.0/19",
+        "MapPublicIpOnLaunch": false,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Private",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Private",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PrivateSubnet1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "vpcA2121C38",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "vpcPrivateSubnet2DefaultRouteB0E07F99": Object {
+      "Properties": Object {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId": Object {
+          "Ref": "vpcPublicSubnet2NATGateway9B8AE11A",
+        },
+        "RouteTableId": Object {
+          "Ref": "vpcPrivateSubnet2RouteTable7280F23E",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "vpcPrivateSubnet2RouteTable7280F23E": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PrivateSubnet2",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "vpcA2121C38",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "vpcPrivateSubnet2RouteTableAssociation007E94D3": Object {
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "vpcPrivateSubnet2RouteTable7280F23E",
+        },
+        "SubnetId": Object {
+          "Ref": "vpcPrivateSubnet2Subnet7031C2BA",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "vpcPrivateSubnet2Subnet7031C2BA": Object {
+      "Properties": Object {
+        "AvailabilityZone": "dummy1b",
+        "CidrBlock": "10.0.128.0/19",
+        "MapPublicIpOnLaunch": false,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Private",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Private",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PrivateSubnet2",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "vpcA2121C38",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "vpcPrivateSubnet3DefaultRoute30C45F47": Object {
+      "Properties": Object {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId": Object {
+          "Ref": "vpcPublicSubnet3NATGateway82F6CA9E",
+        },
+        "RouteTableId": Object {
+          "Ref": "vpcPrivateSubnet3RouteTable24DA79A0",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "vpcPrivateSubnet3RouteTable24DA79A0": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PrivateSubnet3",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "vpcA2121C38",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "vpcPrivateSubnet3RouteTableAssociationC58B3C2C": Object {
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "vpcPrivateSubnet3RouteTable24DA79A0",
+        },
+        "SubnetId": Object {
+          "Ref": "vpcPrivateSubnet3Subnet985AC459",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "vpcPrivateSubnet3Subnet985AC459": Object {
+      "Properties": Object {
+        "AvailabilityZone": "dummy1c",
+        "CidrBlock": "10.0.160.0/19",
+        "MapPublicIpOnLaunch": false,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Private",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Private",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PrivateSubnet3",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "vpcA2121C38",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "vpcPublicSubnet1DefaultRoute10708846": Object {
+      "DependsOn": Array [
+        "vpcVPCGW7984C166",
+      ],
+      "Properties": Object {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": Object {
+          "Ref": "vpcIGWE57CBDCA",
+        },
+        "RouteTableId": Object {
+          "Ref": "vpcPublicSubnet1RouteTable48A2DF9B",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "vpcPublicSubnet1EIPDA49DCBE": Object {
+      "Properties": Object {
+        "Domain": "vpc",
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PublicSubnet1",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::EIP",
+    },
+    "vpcPublicSubnet1NATGateway9C16659E": Object {
+      "Properties": Object {
+        "AllocationId": Object {
+          "Fn::GetAtt": Array [
+            "vpcPublicSubnet1EIPDA49DCBE",
+            "AllocationId",
+          ],
+        },
+        "SubnetId": Object {
+          "Ref": "vpcPublicSubnet1Subnet2E65531E",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PublicSubnet1",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::NatGateway",
+    },
+    "vpcPublicSubnet1RouteTable48A2DF9B": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PublicSubnet1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "vpcA2121C38",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "vpcPublicSubnet1RouteTableAssociation5D3F4579": Object {
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "vpcPublicSubnet1RouteTable48A2DF9B",
+        },
+        "SubnetId": Object {
+          "Ref": "vpcPublicSubnet1Subnet2E65531E",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "vpcPublicSubnet1Subnet2E65531E": Object {
+      "Properties": Object {
+        "AvailabilityZone": "dummy1a",
+        "CidrBlock": "10.0.0.0/19",
+        "MapPublicIpOnLaunch": true,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Public",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Public",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PublicSubnet1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "vpcA2121C38",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "vpcPublicSubnet2DefaultRouteA1EC0F60": Object {
+      "DependsOn": Array [
+        "vpcVPCGW7984C166",
+      ],
+      "Properties": Object {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": Object {
+          "Ref": "vpcIGWE57CBDCA",
+        },
+        "RouteTableId": Object {
+          "Ref": "vpcPublicSubnet2RouteTableEB40D4CB",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "vpcPublicSubnet2EIP9B3743B1": Object {
+      "Properties": Object {
+        "Domain": "vpc",
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PublicSubnet2",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::EIP",
+    },
+    "vpcPublicSubnet2NATGateway9B8AE11A": Object {
+      "Properties": Object {
+        "AllocationId": Object {
+          "Fn::GetAtt": Array [
+            "vpcPublicSubnet2EIP9B3743B1",
+            "AllocationId",
+          ],
+        },
+        "SubnetId": Object {
+          "Ref": "vpcPublicSubnet2Subnet009B674F",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PublicSubnet2",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::NatGateway",
+    },
+    "vpcPublicSubnet2RouteTableAssociation21F81B59": Object {
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "vpcPublicSubnet2RouteTableEB40D4CB",
+        },
+        "SubnetId": Object {
+          "Ref": "vpcPublicSubnet2Subnet009B674F",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "vpcPublicSubnet2RouteTableEB40D4CB": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PublicSubnet2",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "vpcA2121C38",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "vpcPublicSubnet2Subnet009B674F": Object {
+      "Properties": Object {
+        "AvailabilityZone": "dummy1b",
+        "CidrBlock": "10.0.32.0/19",
+        "MapPublicIpOnLaunch": true,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Public",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Public",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PublicSubnet2",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "vpcA2121C38",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "vpcPublicSubnet3DefaultRoute3F356A11": Object {
+      "DependsOn": Array [
+        "vpcVPCGW7984C166",
+      ],
+      "Properties": Object {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": Object {
+          "Ref": "vpcIGWE57CBDCA",
+        },
+        "RouteTableId": Object {
+          "Ref": "vpcPublicSubnet3RouteTableA3C00665",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "vpcPublicSubnet3EIP2C3B9D91": Object {
+      "Properties": Object {
+        "Domain": "vpc",
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PublicSubnet3",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::EIP",
+    },
+    "vpcPublicSubnet3NATGateway82F6CA9E": Object {
+      "Properties": Object {
+        "AllocationId": Object {
+          "Fn::GetAtt": Array [
+            "vpcPublicSubnet3EIP2C3B9D91",
+            "AllocationId",
+          ],
+        },
+        "SubnetId": Object {
+          "Ref": "vpcPublicSubnet3Subnet11B92D7C",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PublicSubnet3",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::NatGateway",
+    },
+    "vpcPublicSubnet3RouteTableA3C00665": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PublicSubnet3",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "vpcA2121C38",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "vpcPublicSubnet3RouteTableAssociationD102D1C4": Object {
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "vpcPublicSubnet3RouteTableA3C00665",
+        },
+        "SubnetId": Object {
+          "Ref": "vpcPublicSubnet3Subnet11B92D7C",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "vpcPublicSubnet3Subnet11B92D7C": Object {
+      "Properties": Object {
+        "AvailabilityZone": "dummy1c",
+        "CidrBlock": "10.0.64.0/19",
+        "MapPublicIpOnLaunch": true,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Public",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Public",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "TestStack/vpc/PublicSubnet3",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "vpcA2121C38",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "vpcVPCGW7984C166": Object {
+      "Properties": Object {
+        "InternetGatewayId": Object {
+          "Ref": "vpcIGWE57CBDCA",
+        },
+        "VpcId": Object {
+          "Ref": "vpcA2121C38",
+        },
+      },
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/test/customsg.test.ts
+++ b/test/customsg.test.ts
@@ -1,0 +1,47 @@
+import { App, Stack, aws_ec2 as ec2 } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { InstanceService } from '../src/index';
+
+
+function setupStack() {
+  const app = new App();
+  const stack = new Stack(app, 'TestStack', {
+    env: {
+      account: '123456789012', // not a real account
+      region: 'us-east-1',
+    },
+  });
+
+  const vpc = new ec2.Vpc(stack, 'vpc');
+
+  return {
+    stack: stack,
+    vpc: vpc,
+  };
+}
+
+test('Snapshot', () => {
+  let setup = setupStack();
+  let stack = setup.stack;
+  let vpc = setup.vpc;
+
+  let ami = ec2.MachineImage.lookup({
+    name: 'Windows_Server-2022-English-Full-Base',
+    windows: true,
+  });
+
+  const securityGroup = new ec2.SecurityGroup(stack, 'sg', {
+    vpc,
+  });
+
+  new InstanceService(stack, 'instanceService', {
+    name: 'snapshot',
+    machineImage: ami,
+    vpc,
+    parentDomain: 'example.com',
+    instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
+    securityGroup,
+  });
+
+  expect(Template.fromStack(stack)).toMatchSnapshot();
+});


### PR DESCRIPTION
Most of the time the default security group is sufficient, but in some cases it may be appropriate to create a security group ahead of time.